### PR TITLE
Improve game look with animated gradient

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@400;600;700&family=Luckiest+Guy&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2,11 +2,13 @@ body, #root, .jackbox-bg {
   min-height: 100vh;
   margin: 0;
   padding: 0;
-  background: linear-gradient(135deg, #f7b42c 0%, #fc575e 100%);
+  background: linear-gradient(135deg, #fc575e, #f7b42c, #61dafb, #a259f7);
+  background-size: 400% 400%;
+  animation: jackbox-gradient 12s ease infinite;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: 'Quicksand', 'Comic Sans MS', 'Arial Rounded MT Bold', Arial, sans-serif;
+  font-family: 'Fredoka', 'Quicksand', 'Comic Sans MS', 'Arial Rounded MT Bold', Arial, sans-serif;
 }
 
 .lobby-container {
@@ -21,12 +23,13 @@ body, #root, .jackbox-bg {
 }
 
 .game-title {
-  font-size: 2.8rem;
+  font-size: 3rem;
   font-weight: 900;
   color: #fc575e;
   margin-bottom: 2rem;
   letter-spacing: 2px;
   text-shadow: 2px 2px 0 #fff, 4px 4px 0 #f7b42c;
+  font-family: 'Luckiest Guy', 'Fredoka', 'Quicksand', sans-serif;
 }
 
 .code-box {
@@ -82,6 +85,7 @@ body, #root, .jackbox-bg {
   cursor: pointer;
   letter-spacing: 2px;
   transition: transform 0.1s, box-shadow 0.1s, background 0.2s;
+  font-family: 'Fredoka', 'Quicksand', sans-serif;
 }
 .start-btn:hover {
   transform: scale(1.07) rotate(-2deg);
@@ -154,6 +158,7 @@ body, #root, .jackbox-bg {
   cursor: pointer;
   letter-spacing: 1px;
   transition: transform 0.1s, box-shadow 0.1s, background 0.2s;
+  font-family: 'Fredoka', 'Quicksand', sans-serif;
 }
 .add-player-btn:hover {
   transform: scale(1.05) rotate(1deg);
@@ -330,4 +335,10 @@ body, #root, .jackbox-bg {
 /* Animate between large and shrunk */
 .prompt-scene, .prompt-box {
   transition: all 0.7s cubic-bezier(.86,0,.07,1);
+}
+
+@keyframes jackbox-gradient {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
 }

--- a/frontend/src/Lobby.jsx
+++ b/frontend/src/Lobby.jsx
@@ -67,7 +67,8 @@ function getRandomBubbleStyle(excludeRect, existingBubbles) {
     '#fc575e', '#f7b42c', '#61dafb', '#a259f7', '#43e97b', '#fcb045', '#f857a6', '#30cfd0', '#fdc830', '#f37335'
   ];
   const color = colors[Math.floor(Math.random() * colors.length)] + 'cc';
-  return { x, y, width, height, color, widthPercent, heightPercent };
+  const rotation = Math.random() * 20 - 10;
+  return { x, y, width, height, color, rotation, widthPercent, heightPercent };
 }
 
 export function PlayerNamesBackground({ players, excludeRect }) {
@@ -96,7 +97,8 @@ export function PlayerNamesBackground({ players, excludeRect }) {
               top: `${bubble.y}%`,
               width: `${bubble.width}rem`,
               height: `${bubble.height}rem`,
-              background: bubble.color
+              background: bubble.color,
+              transform: `rotate(${bubble.rotation}deg)`
             }}
           >
             <span className="bubble-name">{name}</span>


### PR DESCRIPTION
## Summary
- embed Google fonts in frontend
- animate lobby background gradient and use updated fonts
- rotate player name bubbles for more playful Jackbox feel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687f9f5ca1f0833398d11ba5e33064b1